### PR TITLE
Add typing annotations to character and monster logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import random
+from typing import Optional
 
-from item import Weapon
-from item import RangedWeapon
 from item import Armor
+from item import Item
+from item import RangedWeapon
 from item import Shield
+from item import Weapon
 from scelta_classe import choose_class
 from scelta_razza import choose_race
 from storia import adventure
@@ -13,7 +15,7 @@ race_number = int(input("1. Umano, 2. Nano, 3. Elfo, 4. Gnomo"))
 class_number = int(input("1. Barbaro, 2. Paladino, 3. Ladro, 4. Mago"))
 selected_race = choose_race(race_number)
 selected_class = choose_class(class_number)
-selected_item = None
+selected_item: Optional[Item] = None
 if race_number == 1:
     selected_item = Weapon("Mazza", 10, 10)
 if race_number == 2:
@@ -25,7 +27,8 @@ if race_number == 4:
 character_name = input("Dimmi il nome del tuo personaggio")
 sale_price = int(random.uniform(1, 10))
 selected_character = Character(character_name, selected_race, selected_class)
-selected_character.equip_item(selected_item)
+if selected_item is not None:
+    selected_character.equip_item(selected_item)
 print(selected_character)
 while not selected_character.is_dead():
     adventure(selected_character)

--- a/mostro.py
+++ b/mostro.py
@@ -1,3 +1,6 @@
+from typing import Iterable
+
+import item as it
 from personaggio import Character
 
 
@@ -5,23 +8,23 @@ class Monster(Character):
 
     experience_reward = 0
 
-    def populate_inventory(self, items):
+    def populate_inventory(self, items: Iterable[it.Item]) -> None:
         for item in items:
             self.add_item(item)
 
-    def set_experience_reward(self, experience):
+    def set_experience_reward(self, experience: int) -> None:
         if experience <= 0:
             print("Experience must be greater than 0")
             return
         self.experience_reward = experience
 
-    def set_coin_reward(self, coins):
+    def set_coin_reward(self, coins: int) -> None:
         if coins <= 0:
             print("Coins must be greater than 0")
             return
         self.coins = coins
 
-    def die(self, attacker):
+    def die(self, attacker: Character) -> None:
         for item in self.inventory:
             attacker.add_item(item)
         attacker.gain_experience(self.experience_reward)

--- a/personaggio.py
+++ b/personaggio.py
@@ -1,45 +1,42 @@
+from __future__ import annotations
+
 import random
 import math
+from typing import Any, Iterable, Optional, Union
 
 from dado import d20
 import item as it
 
+InventoryItems = Iterable[it.Item]
+CharacterWeapon = Optional[Union[it.Weapon, it.RangedWeapon]]
+
 
 class Character:
-    strength = 0
-    dexterity = 0
-    constitution = 0
-    intelligence = 0
-    wisdom = 0
-    charisma = 0
-    experience = 0
-    level = 1
-    coins = 0
-    initial_hit_points = 0
-    max_hit_points = 0
-    current_hit_points = 0
-    name = ""
-    race = None
-    character_class = None
-    inventory = []
-    melee_weapon = None
-    ranged_weapon = None
-    shield = None
-    armor = None
 
-    def __init__(self, name, race, character_class):
+    def __init__(self, name: str, race: Any, character_class: Any) -> None:
         self.coins = character_class.get_coins()
         self.name = name
         self.race = race
         self.character_class = character_class
-        self.inventory = []
-        self.melee_weapon = None
-        self.ranged_weapon = None
-        self.shield = None
-        self.armor = None
+        self.level = 1
+        self.experience = 0
+        self.inventory: list[it.Item] = []
+        self.melee_weapon: Optional[it.Weapon] = None
+        self.ranged_weapon: Optional[it.RangedWeapon] = None
+        self.shield: Optional[it.Shield] = None
+        self.armor: Optional[it.Armor] = None
+        self.strength = 0
+        self.dexterity = 0
+        self.constitution = 0
+        self.intelligence = 0
+        self.wisdom = 0
+        self.charisma = 0
+        self.initial_hit_points = 0
+        self.max_hit_points = 0
+        self.current_hit_points = 0
         self.assign_points()
 
-    def assign_points(self, bonus_points=30):
+    def assign_points(self, bonus_points: int = 30) -> None:
         self.strength = 8 + self.race.get_strength()
         self.dexterity = 8 + self.race.get_dexterity()
         self.constitution = 8 + self.race.get_constitution()
@@ -67,43 +64,43 @@ class Character:
         self.max_hit_points = self.initial_hit_points
         self.current_hit_points = self.max_hit_points
 
-    def gain_experience(self, points):
+    def gain_experience(self, points: int) -> None:
         self.experience += points
         while self.experience >= self.experience_to_level_up():
             self.experience -= self.experience_to_level_up()
             self.level_up()
 
-    def experience_to_level_up(self):
+    def experience_to_level_up(self) -> int:
         return int(100 * self.level * (self.level + 1) / 2)
 
-    def level_up(self):
+    def level_up(self) -> None:
         self.level += 1
         bonus_hit_points = math.ceil(2 + (self.character_class.get_die() / 2) + self.constitution)
         self.max_hit_points += bonus_hit_points
         self.current_hit_points = self.max_hit_points
 
-    def earn_coins(self, coins):
+    def earn_coins(self, coins: int) -> None:
         if coins <= 0:
             print("Coins cannot be less than zero")
             return
         self.coins += coins
 
-    def add_item(self, item):
+    def add_item(self, item: it.Item) -> None:
         self.inventory.append(item)
         print(f"Item {item.name} added to {self.name}'s inventory")
 
-    def sell_item(self, item):
+    def sell_item(self, item: it.Item) -> None:
         if item in self.inventory:
             self.inventory.remove(item)
             self.coins += item.sale_cost
 
-    def buy_item(self, item):
+    def buy_item(self, item: it.Item) -> None:
         purchase_cost = getattr(item, "purchase_cost", item.sale_cost)
         if self.coins >= purchase_cost:
             self.inventory.append(item)
             self.coins -= purchase_cost
 
-    def equip_item(self, item):
+    def equip_item(self, item: it.Item) -> None:
         self.add_item(item)
         if isinstance(item, it.Weapon):
             self.melee_weapon = item
@@ -114,7 +111,13 @@ class Character:
         if isinstance(item, it.Armor):
             self.armor = item
 
-    def attack(self, target, base_damage, character_weapon, bonus):
+    def attack(
+        self,
+        target: "Character",
+        base_damage: int,
+        character_weapon: CharacterWeapon,
+        bonus: int,
+    ) -> None:
         if self.is_dead():
             print()
             return
@@ -132,13 +135,13 @@ class Character:
         else:
             print("Attack missed")
 
-    def melee_attack(self, target):
+    def melee_attack(self, target: "Character") -> None:
         self.attack(target, self.strength, self.melee_weapon, self.strength)
 
-    def ranged_attack(self, target):
+    def ranged_attack(self, target: "Character") -> None:
         self.attack(target, self.dexterity, self.ranged_weapon, self.dexterity)
 
-    def attack_hits(self, target, bonus):
+    def attack_hits(self, target: "Character", bonus: int) -> bool:
         roll = d20()
         if roll == 1:
             return False
@@ -149,7 +152,7 @@ class Character:
                 return True
         return False
 
-    def get_armor_class(self):
+    def get_armor_class(self) -> float:
         armor_class = 10 + (self.dexterity / 2)
         if self.armor is not None:
             armor_class += self.armor.defense
@@ -157,33 +160,33 @@ class Character:
             armor_class += self.shield.defense
         return armor_class
 
-    def take_damage(self, attacker, damage):
+    def take_damage(self, attacker: "Character", damage: int) -> None:
         self.current_hit_points -= damage
         if self.current_hit_points <= 0:
             self.current_hit_points = 0
             self.die(attacker)
 
-    def die(self, attacker):
+    def die(self, attacker: "Character") -> None:
         print(f"{self.name} killed by {attacker.name}")
 
-    def is_dead(self):
+    def is_dead(self) -> bool:
         if self.current_hit_points <= 0:
             return True
         return False
 
-    def observe(self, difficulty):
+    def observe(self, difficulty: int) -> bool:
         total = 2 + self.wisdom + d20()
         if total > difficulty:
             return True
         return False
 
-    def listen(self, difficulty):
+    def listen(self, difficulty: int) -> bool:
         total = 2 + self.charisma + d20()
         if total > difficulty:
             return True
         return False
 
-    def __str__(self):
+    def __str__(self) -> str:
         description = (
             f"Name: {self.name}, Race: {self.race.get_name()}, Class: {self.character_class.get_name()} "
             f"(Level {self.level})\n"
@@ -201,6 +204,7 @@ class Character:
         description += "Equipment:\n"
         description += f"{self.melee_weapon}\n{self.ranged_weapon}\n{self.armor}\n{self.shield}\n"
         description += "Inventory: \n"
-        for item in self.inventory:
+        inventory_items: InventoryItems = self.inventory
+        for item in inventory_items:
             description += item.__str__() + "\n"
         return description


### PR DESCRIPTION
## Summary
- enable postponed annotations in `Character` and add explicit typing across combat and inventory APIs
- tighten monster helper types to accept typed item iterables and character attackers
- adjust main entrypoint setup to satisfy stricter item typing during character creation

## Testing
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68d65150fd548324b844a3627a82b60d